### PR TITLE
ci: restore GitHub Actions build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build TypeScript
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 14
+          cache: yarn
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --ignore-scripts
+      - name: Build
+        run: yarn build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🐦 @a11yisimportant
 
-[![Travis CI](https://img.shields.io/travis/AnandChowdhary/a11yisimportant.svg)](https://travis-ci.org/AnandChowdhary/a11yisimportant)
+[![Build](https://img.shields.io/github/actions/workflow/status/AnandChowdhary/a11yisimportant/build.yml?branch=master&label=Build&logo=github)](https://github.com/AnandChowdhary/a11yisimportant/actions/workflows/build.yml)
 [![Coverage Status](https://coveralls.io/repos/github/AnandChowdhary/a11yisimportant/badge.svg?branch=master)](https://coveralls.io/github/AnandChowdhary/a11yisimportant?branch=master)
 [![GitHub](https://img.shields.io/github/license/anandchowdhary/a11yisimportant.svg)](https://github.com/AnandChowdhary/a11yisimportant/blob/master/LICENSE)
 [![Vulnerabilities](https://img.shields.io/snyk/vulnerabilities/github/AnandChowdhary/a11yisimportant.svg)](https://snyk.io/test/github/AnandChowdhary/a11yisimportant)

--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,7 @@ interface TwitterOptions {
   access_token_key: string;
   access_token_secret: string;
 }
-const defaultOptions = {
+const defaultOptions: TwitterOptions = {
   screen_name: "a11yisimportant",
   hashtag: "a11y",
   consumer_key: process.env.API_KEY as string,
@@ -270,6 +270,7 @@ const likeTweets = async (tweets: Tweet[], options: TwitterOptions) => {
 };
 
 export {
+  defaultOptions,
   followProcess,
   unfollowProcess,
   retweetProcess,
@@ -279,5 +280,6 @@ export {
   getTweet,
   likeTweets,
   likeTweet,
-  likeProcess
+  likeProcess,
+  TwitterOptions
 };

--- a/package.json
+++ b/package.json
@@ -59,5 +59,11 @@
       "node"
     ]
   },
+  "resolutions": {
+    "@types/body-parser": "1.19.0",
+    "@types/express-serve-static-core": "4.17.13",
+    "@types/qs": "6.9.4",
+    "@types/serve-static": "1.13.5"
+  },
   "snyk": true
 }

--- a/server.ts
+++ b/server.ts
@@ -2,38 +2,65 @@ import express, { Response, Request } from "express";
 const app = express();
 
 import {
+  defaultOptions,
   followProcess,
   unfollowProcess,
   retweetProcess,
-  likeProcess
+  likeProcess,
+  TwitterOptions
 } from "./index";
+
+const twitterOptionKeys: Array<keyof TwitterOptions> = [
+  "screen_name",
+  "hashtag",
+  "consumer_key",
+  "consumer_secret",
+  "access_token_key",
+  "access_token_secret"
+];
+
+const stringQueryValue = (value: unknown): string | undefined =>
+  typeof value === "string" && value ? value : undefined;
+
+const twitterOptionsFromQuery = (
+  query: Request["query"]
+): TwitterOptions | undefined => {
+  const overrides = twitterOptionKeys.reduce((options, key) => {
+    const value = stringQueryValue(query[key]);
+    return value ? { ...options, [key]: value } : options;
+  }, {} as Partial<TwitterOptions>);
+
+  return Object.keys(overrides).length
+    ? { ...defaultOptions, ...overrides }
+    : undefined;
+};
 
 app.get("/", (req: Request, res: Response) => res.json({ hello: "world" }));
 
 app.get("/follow", (req: Request, res: Response) => {
   res.json({ queued: "follow" });
-  followProcess(false, Object.keys(req.query).length ? req.query : undefined)
+  followProcess(false, twitterOptionsFromQuery(req.query))
     .then(() => {})
     .catch(e => console.log("Got error", e));
 });
 
 app.get("/unfollow", (req: Request, res: Response) => {
   res.json({ queued: "unfollow" });
-  unfollowProcess(false, Object.keys(req.query).length ? req.query : undefined)
+  unfollowProcess(false, twitterOptionsFromQuery(req.query))
     .then(() => {})
     .catch(e => console.log("Got error", e));
 });
 
 app.get("/retweet", (req: Request, res: Response) => {
   res.json({ queued: "retweet" });
-  retweetProcess(false, Object.keys(req.query).length ? req.query : undefined)
+  retweetProcess(false, twitterOptionsFromQuery(req.query))
     .then(() => {})
     .catch(e => console.log("Got error", e));
 });
 
 app.get("/like", (req: Request, res: Response) => {
   res.json({ queued: "like" });
-  likeProcess(false, Object.keys(req.query).length ? req.query : undefined)
+  likeProcess(false, twitterOptionsFromQuery(req.query))
     .then(() => {})
     .catch(e => console.log("Got error", e));
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -741,10 +741,10 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/body-parser@*":
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.17.0.tgz#9f5c9d9bd04bb54be32d5eb9fc0d8c974e6cf58c"
-  integrity sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==
+"@types/body-parser@*", "@types/body-parser@1.19.0":
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.0.tgz#0685b3c47eb3006ffed117cdd55164b61f80538f"
+  integrity sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==
   dependencies:
     "@types/connect" "*"
     "@types/node" "*"
@@ -788,12 +788,13 @@
   dependencies:
     dotenv "*"
 
-"@types/express-serve-static-core@*":
-  version "4.16.1"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.16.1.tgz#35df7b302299a4ab138a643617bd44078e74d44e"
-  integrity sha512-QgbIMRU1EVRry5cIu1ORCQP4flSYqLM1lS5LYyGWfKnFT3E58f0gKto7BR13clBFVrVZ0G0rbLZ1hUpSkgQQOA==
+"@types/express-serve-static-core@*", "@types/express-serve-static-core@4.17.13":
+  version "4.17.13"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.13.tgz#d9af025e925fc8b089be37423b8d1eac781be084"
+  integrity sha512-RgDi5a4nuzam073lRGKTUIaL3eF2+H7LJvJ8eUnCI0wA6SNjXc44DCmWNiTLs/AZ7QlsFWZiw/gTG3nSQGL0fA==
   dependencies:
     "@types/node" "*"
+    "@types/qs" "*"
     "@types/range-parser" "*"
 
 "@types/express@^4.17.8":
@@ -915,10 +916,10 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
   integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
 
-"@types/qs@*":
-  version "6.9.1"
-  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.1.tgz#937fab3194766256ee09fcd40b781740758617e7"
-  integrity sha512-lhbQXx9HKZAPgBkISrBcmAcMpZsmpe/Cd/hY7LGZS5OfkySUBItnPZHgQPssWYUET8elF+yCFBbP1Q0RZPTdaw==
+"@types/qs@*", "@types/qs@6.9.4":
+  version "6.9.4"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.4.tgz#a59e851c1ba16c0513ea123830dd639a0a15cb6a"
+  integrity sha512-+wYo+L6ZF6BMoEjtf8zB2esQsqdV6WsjRK/GP9WOgLPrq87PbNWgIxS76dS5uvl/QXtHGakZmwTznIfcPXcKlQ==
 
 "@types/range-parser@*":
   version "1.2.3"
@@ -947,10 +948,10 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"
   integrity sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==
 
-"@types/serve-static@*":
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.2.tgz#f5ac4d7a6420a99a6a45af4719f4dcd8cd907a48"
-  integrity sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==
+"@types/serve-static@*", "@types/serve-static@1.13.5":
+  version "1.13.5"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.5.tgz#3d25d941a18415d3ab092def846e135a08bbcf53"
+  integrity sha512-6M64P58N+OXjU432WoLLBQxbA0LRGBCRm7aAGQJ+SMC1IMl0dgRVi9EFfoDcS2a7Xogygk/eGN94CfwU9UF7UQ==
   dependencies:
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions build workflow to replace the retired Travis CI signal
- Updates the README build badge to point at the new workflow
- Pins stale transitive Express type packages and normalizes query parameters so `yarn build` works again

## Test Plan
- `npx -y -p node@14 -p yarn@1.22.22 yarn install --frozen-lockfile --ignore-scripts`
- `npx -y -p node@14 -p yarn@1.22.22 yarn build`
- YAML parsed with PyYAML
- `actionlint -stdin-filename .github/workflows/build.yml -`
- `git diff --check`

Note: the existing Jest suite still requires live Twitter credentials and fails locally with `Bad Authentication data`; this PR restores the deterministic TypeScript build path.

Related to #705.
